### PR TITLE
Cell render

### DIFF
--- a/bob/csvutil.py
+++ b/bob/csvutil.py
@@ -17,6 +17,7 @@ import csv
 
 from django.http import HttpResponse
 
+
 class excel_semicolon(csv.excel):
     delimiter = b';'
 
@@ -33,6 +34,7 @@ class UTF8Recoder:
 
     def next(self):
         return self.reader.next().encode("utf-8")
+
 
 class UnicodeReader:
     """

--- a/bob/data_table.py
+++ b/bob/data_table.py
@@ -1,11 +1,12 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import cStringIO as StringIO
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from django.core.paginator import Paginator, EmptyPage
 from django.db.models import FieldDoesNotExist
-from django.http import HttpResponse
 
 from bob import csvutil
 
@@ -58,7 +59,6 @@ class DataTableColumn(object):
         return '<td>{}</td>'.format(self.render_cell_content(resource))
 
 
-
 class DataTableMixin(object):
     """Add this Mixin to your django view to handle page pagination.
 
@@ -81,9 +81,10 @@ class DataTableMixin(object):
 
     In your template add code::
 
-    {% pagination bob_page url_query=url_query show_all=0 show_csv=0 fugue_icons=1 sort_variable_name %}
+    {% pagination bob_page url_query=url_query show_all=0 show_csv=0 fugue_icons=1 sort_variable_name %}  # noqa
 
-    where ``query_variable_name`` - is the name of the attribute used for pagination, and::
+    where ``query_variable_name`` - is the name of the attribute used
+        for pagination, and::
 
     {% table_header columns url_query sort fugue_icons%}
 

--- a/bob/forms/__init__.py
+++ b/bob/forms/__init__.py
@@ -4,5 +4,5 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from bob.forms.widgets import *
-from bob.forms.dependency import *
+from bob.forms.widgets import *  # noqa
+from bob.forms.dependency import *  # noqa

--- a/bob/forms/widgets.py
+++ b/bob/forms/widgets.py
@@ -10,15 +10,18 @@ from django.forms.util import flatatt
 from django.utils.html import escape
 from django.utils import simplejson as json
 
+
 class AutocompleteWidget(forms.Select):
     """A choice widget using a text field with Bootstrap's autocomplete."""
 
     def render(self, name, value, attrs=None, choices=()):
-        if value is None: value = ''
+        if value is None:
+            value = ''
         final_attrs = self.build_attrs(attrs, name=name)
         labels = dict(self.choices)
         output = [
-            u'<input type="text" autocomplete="off" data-provide="typeahead" data-items="10" data-source="%s" value="%s" %s>' % (
+            u'<input type="text" autocomplete="off" data-provide="typeahead" '
+            'data-items="10" data-source="%s" value="%s" %s>' % (
                 escape(
                     json.dumps(zip(*self.choices)[1] if self.choices else [])
                 ),
@@ -31,7 +34,7 @@ class AutocompleteWidget(forms.Select):
         value = data.get(name, None)
         if value == '---------':
             return None
-        values = dict((label, value) for value, label in self.choices )
+        values = dict((label, value) for value, label in self.choices)
         return values.get(value, value)
 
 
@@ -45,7 +48,7 @@ class DateWidget(forms.DateInput):
     """A date widget using jQuery date picker."""
 
     def render(self, name, value='', attrs=None, choices=()):
-        attr_class =  escape(self.attrs.get('class', ''))
+        attr_class = escape(self.attrs.get('class', ''))
         attr_placeholder = escape(self.attrs.get('placeholder', ''))
         output = ('<input type="text" name="%s" class="datepicker %s" '
                   'placeholder="%s" value="%s" data-date-format="yyyy-mm-dd">')

--- a/bob/menu.py
+++ b/bob/menu.py
@@ -1,4 +1,12 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from django.core.urlresolvers import reverse
+
 
 class MenuItem(object):
     """
@@ -18,8 +26,10 @@ class MenuItem(object):
     :param view_kwargs: The keyword arguments for the URL rule.
     :param icon: A Bootstrap icon to show for this item.
     :param fugue_icon: A Fugue icon to show for this item, if available.
-    :param collapsible: Whether the submenu should be collapsible. Default ``False``.
-    :param collapsed: Whether the submenu should start collapsed. Default ``False``.
+    :param collapsible: Whether the submenu should be collapsible.
+        Default ``False``.
+    :param collapsed: Whether the submenu should start collapsed.
+        Default ``False``.
     :param indent: A string by which the item should be indented.
     """
 
@@ -65,4 +75,3 @@ class MenuHeader(object):
 
     def __init__(self, label):
         self.label = label
-

--- a/bob/templatetags/bob.py
+++ b/bob/templatetags/bob.py
@@ -132,8 +132,10 @@ def pagination(page, show_all=False, show_csv=False,
         }
     paginator = page.paginator
     page_no = page.number
-    pages = paginator.page_range[max(0, page_no - 1 - neighbors):
-    min(paginator.num_pages, page_no + neighbors)]
+    pages = paginator.page_range[
+        max(0, page_no - 1 - neighbors):
+        min(paginator.num_pages, page_no + neighbors)
+    ]
 
     if 1 not in pages:
         pages.insert(0, 1)
@@ -157,8 +159,16 @@ def pagination(page, show_all=False, show_csv=False,
         'show_csv': show_csv,
         'fugue_icons': fugue_icons,
         'url_query': url_query,
-        'url_previous_page': changed_url(url_query, query_variable_name, page_no-1),
-        'url_next_page': changed_url(url_query, query_variable_name, page_no+1),
+        'url_previous_page': changed_url(
+            url_query,
+            query_variable_name,
+            page_no - 1
+        ),
+        'url_next_page': changed_url(
+            url_query,
+            query_variable_name,
+            page_no + 1
+        ),
         'url_pages': url_pages,
         'url_all': changed_url(url_query, query_variable_name, 0),
         'export_variable_name': export_variable_name,
@@ -290,6 +300,7 @@ def bob_sort_url(query, field, sort_variable_name, type):
         query[sort_variable_name] = field
     return query.urlencode()
 
+
 @register.simple_tag
 def bob_export_url(query, value, export_variable_name='export'):
     """Modify the query string of an URL to change the ``export_variable_name``
@@ -307,6 +318,7 @@ def bob_export_url(query, value, export_variable_name='export'):
             pass
     return query.urlencode()
 
+
 @register.simple_tag
 def dependency_data(form):
     """Render the data-bob-dependencies tag if this is a DependencyForm"""
@@ -315,6 +327,7 @@ def dependency_data(form):
         return ''
     return 'data-bob-dependencies="{0}"'.format(
         esc(json.dumps(form.get_dependencies_for_js())))
+
 
 @register.inclusion_tag('bob/field_wrapper.html')
 def field_wrapper(field):

--- a/bob/views/__init__.py
+++ b/bob/views/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 """Views usefull in advanced django forms."""
-from dependency import DependencyView
+
+from dependency import DependencyView  # noqa


### PR DESCRIPTION
I have added an ability to specify a 'render_cell' method on columns. This can be used to make table rendering in ralph_assets DRYer (no need to specify each column in template).
