### PR TITLE
Remove simple json import for compatibility with Django>=1.5

### DIFF
--- a/bob/forms/widgets.py
+++ b/bob/forms/widgets.py
@@ -4,11 +4,12 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import json
+
 from django import forms
 from django.utils.safestring import mark_safe
 from django.forms.util import flatatt
 from django.utils.html import escape
-from django.utils import simplejson as json
 
 
 class AutocompleteWidget(forms.Select):


### PR DESCRIPTION
Use `json` from Python standard library.
