### PR TITLE
Classes in tab_menu

### DIFF
--- a/bob/templates/bob/tab_menu_bs3fake.html
+++ b/bob/templates/bob/tab_menu_bs3fake.html
@@ -1,7 +1,9 @@
+{%load bob %}
 <ul class="nav nav-tabs nav-submenu bs3fake">
     {% for item in items %}
         <li class="
         {% if item.name == selected %}active{% endif %}
+        {{ class_prefix|default:'menu-item' }}-{{ item.name|slugify }}
         ">
         <a href="{{ item.get_href }}">{{ item.label }}</a>
     {% endfor %}


### PR DESCRIPTION
We need classes in menu, so the 'beast' and 'ralph CLI' buttons work.
