### PR TITLE
Removed bad css rule

### DIFF
--- a/bob/static/bootstrap/css/bs3fake.css
+++ b/bob/static/bootstrap/css/bs3fake.css
@@ -71,7 +71,6 @@ ul.bs3fake.nav-submenu {
 }
 
 ul.bs3fake.nav-submenu li {
-    height: 110;
     background-color: #3c8dbc;
 }
 


### PR DESCRIPTION
This rule was sometimes interpreted as 110px and sometimes as nothing. Don't know why. It isn't needed anyhow.